### PR TITLE
chore: bump versions

### DIFF
--- a/defaults/main/authentik.yml
+++ b/defaults/main/authentik.yml
@@ -1,7 +1,7 @@
 ---
 ### Authentik ###
 # Version of the authentik Docker image to use (see 'infra_authentik_container_image')
-infra_authentik_version: 2024.12.3
+infra_authentik_version: 2025.6.4
 # Version of the redis Docker image to use (see 'infra_authentik_redis_container_image')
 infra_authentik_redis_version: alpine
 # Version of the posgresql Docker image to use (see 'infra_authentik_db_container_image')

--- a/defaults/main/godns.yml
+++ b/defaults/main/godns.yml
@@ -1,7 +1,7 @@
 ---
 ### godns ###
 # Version of the godns Docker image to use (see 'infra_godns_container_image')
-infra_godns_version: 3.2.2
+infra_godns_version: 3.2.5
 
 # Settings for the godns container. See https://github.com/TimothyYe/godns#configuration-properties
 # DNS provider to use

--- a/defaults/main/pihole.yml
+++ b/defaults/main/pihole.yml
@@ -1,7 +1,7 @@
 ---
 ### Pihole ###
 # Version of the pihole Docker image to use (see 'infra_pihole_container_image')
-infra_pihole_version: 2024.07.0
+infra_pihole_version: 2025.08.0
 
 ## authentik forward auth proxy
 # whether to use authentik as an auth proxy

--- a/defaults/main/unifi.yml
+++ b/defaults/main/unifi.yml
@@ -1,7 +1,7 @@
 ---
 ### Unifi ###
 # Version of the unifi Docker image to use (see 'infra_unifi_container_image')
-infra_unifi_version: 9.0.114
+infra_unifi_version: 9.3.45
 # Version of the MongoDB Docker image to use
 infra_unifi_db_version: 8.0
 

--- a/defaults/main/uptimekuma.yml
+++ b/defaults/main/uptimekuma.yml
@@ -1,7 +1,7 @@
 ---
 ### uptime-kuma ###
 # Version of the uptime-kuma Docker image to use (see 'infra_uptimekuma_container_image')
-infra_uptimekuma_version: 1.23.11-alpine
+infra_uptimekuma_version: 1.23.16-alpine
 
 ## authentik forward auth proxy
 # whether to use authentik as an auth proxy

--- a/defaults/main/vaultwarden.yml
+++ b/defaults/main/vaultwarden.yml
@@ -1,7 +1,7 @@
 ---
 ### Vaultwarden ###
 # Version of the vaultwarden Docker image to use (see 'infra_vaultwarden_container_image')
-infra_vaultwarden_version: 1.33.2
+infra_vaultwarden_version: 1.34.3
 
 ## authentik forward auth proxy
 # whether to use authentik as an auth proxy

--- a/templates/compose/authentik.yml.j2
+++ b/templates/compose/authentik.yml.j2
@@ -85,8 +85,10 @@ services:
     dns: {{ infra_container_dns_servers }}
 {% endif %}
     depends_on:
-      - {{ infra_authentik_redis_service_name }}
-      - {{ infra_authentik_db_service_name }}
+      {{ infra_authentik_redis_service_name }}:
+        condition: service_healthy
+      {{ infra_authentik_db_service_name }}:
+        condition: service_healthy
     command: server
 
   {{ infra_authentik_worker_service_name }}:
@@ -111,8 +113,10 @@ services:
     dns: {{ infra_container_dns_servers }}
 {% endif %}
     depends_on:
-      - {{ infra_authentik_redis_service_name }}
-      - {{ infra_authentik_db_service_name }}
+      {{ infra_authentik_redis_service_name }}:
+        condition: service_healthy
+      {{ infra_authentik_db_service_name }}:
+        condition: service_healthy
     command: worker
 
 volumes:

--- a/templates/compose/pihole.yml.j2
+++ b/templates/compose/pihole.yml.j2
@@ -73,6 +73,8 @@ services:
       - {{ infra_pihole_port_dns }}:53/tcp
       - {{ infra_pihole_port_dns }}:53/udp
       - {{ infra_pihole_port_web }}:80/tcp
+    cap_add:
+      - SYS_NICE
     extra_hosts: {{ infra_pihole_extra_hosts }}
     group_add:
       - {{ infra_group_gid }}

--- a/templates/etc/unbound/unbound.conf.j2
+++ b/templates/etc/unbound/unbound.conf.j2
@@ -16,7 +16,7 @@ server:
     # data in the cache is as the domain owner intended, higher values,
     # especially more than an hour or so, can lead to trouble as the data in
     # the cache does not match up with the actual data any more.
-    cache-min-ttl: 60
+    cache-min-ttl: 300
 
     # Set the working directory for the program.
     directory: "/opt/unbound/etc/unbound"

--- a/vars/main/pihole.yml
+++ b/vars/main/pihole.yml
@@ -5,9 +5,9 @@ infra_pihole_env_vars:
   PGID: "{{ infra_group_gid | string }}"
   TZ: "{{ infra_tz | default('Etc/UTC') | string }}"
   WEBPASSWORD_FILE: "/run/secrets/{{ infra_pihole_password_name }}"
-  VIRTUAL_HOST: "{{ infra_pihole_fqdn }}"
-  DNSMASQ_LISTENING: "{{ infra_pihole_dnsmasq_listening }}"
+  FTLCONF_dns_listeningMode: "{{ infra_pihole_dnsmasq_listening }}"
   FTLCONF_LOCAL_IPV4: "{{ ansible_host }}"
+  FTLCONF_misc_etc_dnsmasq_d: 'true'
 
 # DNS environment variables placeholder for the Pihole container
 infra_pihole_env_vars_dns: {}


### PR DESCRIPTION
Bump services to latest versions:
- Authentik
- GODNS
- Pihole
- Unifi
- Uptime Kuma
- Vaultwarden
