### PR TITLE
ci: bump molecule to run on latest distro versions

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -30,8 +30,8 @@ jobs:
     strategy:
       matrix:
         distro:
-          - debian11
-          - ubuntu2204
+          - debian13
+          - ubuntu2404
     steps:
       - name: Delete unnecessary tools folder (disk space constraint)
         run: rm -rf /opt/hostedtoolcache


### PR DESCRIPTION
- Bump molecule to run on debian13 and ubuntu2404