### PR TITLE
chore: update services

### DIFF
--- a/defaults/main/actual.yml
+++ b/defaults/main/actual.yml
@@ -1,7 +1,7 @@
 ---
 ### actual ###
 # Version of the actual Docker image to use (see 'infra_actual_container_image')
-infra_actual_version: 26.5.0
+infra_actual_version: "26.7.0"
 
 ## actual settings - see https://actualbudget.org/docs/config/
 infra_actual_settings: {}

--- a/defaults/main/authentik.yml
+++ b/defaults/main/authentik.yml
@@ -1,7 +1,7 @@
 ---
 ### Authentik ###
 # Version of the authentik Docker image to use (see 'infra_authentik_container_image')
-infra_authentik_version: 2025.10.1
+infra_authentik_version: 2025.12.5
 # Version of the posgresql Docker image to use (see 'infra_authentik_db_container_image')
 infra_authentik_db_version: 16-alpine
 

--- a/defaults/main/authentik.yml
+++ b/defaults/main/authentik.yml
@@ -21,19 +21,11 @@ infra_authentik_db_name: "authentik"
 infra_authentik_settings:
   AUTHENTIK_COOKIE_DOMAIN: "{{ infra_domain }}"
   AUTHENTIK_LOG_LEVEL: 'info'
-  AUTHENTIK_GEOIP: /geoip/GeoLite2-City.mmdb
   AUTHENTIK_DISABLE_UPDATE_CHECK: 'false'
   AUTHENTIK_ERROR_REPORTING__ENABLED: 'false'
   AUTHENTIK_ERROR_REPORTING__SENTRY_DSN: ""
   AUTHENTIK_ERROR_REPORTING__ENVIRONMENT: customer
   AUTHENTIK_ERROR_REPORTING__SEND_PII: 'false'
-  AUTHENTIK_AVATARS: initials
-  AUTHENTIK_DEFAULT_USER_CHANGE_NAME: 'true'
-  AUTHENTIK_DEFAULT_USER_CHANGE_EMAIL: 'false'
-  AUTHENTIK_DEFAULT_USER_CHANGE_USERNAME: 'false'
-  AUTHENTIK_GDPR_COMPLIANCE: 'true'
-  AUTHENTIK_DEFAULT_TOKEN_LENGTH: '60'
-  AUTHENTIK_IMPERSONATION: 'false'
   AUTHENTIK_EMAIL__HOST: 'localhost'
   AUTHENTIK_EMAIL__PORT: '25'
   AUTHENTIK_EMAIL__USERNAME: ""
@@ -60,7 +52,7 @@ infra_authentik_subdirectory_group: 1000
 infra_authentik_subdirectory_mode: "0750"
 # Subdirectories to create
 infra_authentik_subdirectories:
-  - media
+  - data
   - certs
   - templates
 

--- a/defaults/main/godns.yml
+++ b/defaults/main/godns.yml
@@ -1,7 +1,7 @@
 ---
 ### godns ###
 # Version of the godns Docker image to use (see 'infra_godns_container_image')
-infra_godns_version: v3.4.1
+infra_godns_version: "v3.4.2"
 
 # Settings for the godns container. See https://github.com/TimothyYe/godns#configuration-properties
 # DNS provider to use

--- a/defaults/main/homarr.yml
+++ b/defaults/main/homarr.yml
@@ -1,7 +1,7 @@
 ---
 ### homarr ###
 # Version of the homarr Docker image to use (see 'infra_homarr_container_image')
-infra_homarr_version: v1.59.2
+infra_homarr_version: "v1.69.2"
 # Secret encryption key for Homarr. Generate with `openssl rand -hex 32`.
 infra_homarr_secret_encryption_key: ~
 

--- a/defaults/main/pihole.yml
+++ b/defaults/main/pihole.yml
@@ -1,7 +1,7 @@
 ---
 ### Pihole ###
 # Version of the pihole Docker image to use (see 'infra_pihole_container_image')
-infra_pihole_version: 2026.04.1
+infra_pihole_version: "2026.06.0"
 
 ## authentik forward auth proxy
 # whether to use authentik as an auth proxy

--- a/defaults/main/unifi.yml
+++ b/defaults/main/unifi.yml
@@ -1,7 +1,7 @@
 ---
 ### Unifi ###
 # Version of the unifi Docker image to use (see 'infra_unifi_container_image')
-infra_unifi_version: 10.3.58
+infra_unifi_version: "10.4.57"
 # Version of the MongoDB Docker image to use
 infra_unifi_db_version: 8.0
 

--- a/defaults/main/uptimekuma.yml
+++ b/defaults/main/uptimekuma.yml
@@ -1,7 +1,7 @@
 ---
 ### uptime-kuma ###
 # Version of the uptime-kuma Docker image to use (see 'infra_uptimekuma_container_image')
-infra_uptimekuma_version: 2.0.2
+infra_uptimekuma_version: "2.4.0"
 
 ## authentik forward auth proxy
 # whether to use authentik as an auth proxy

--- a/defaults/main/wazuh.yml
+++ b/defaults/main/wazuh.yml
@@ -1,9 +1,9 @@
 ---
 ### wazuh ###
 # Version of the wazuh Docker image to use (see 'infra_wazuh_manager_container_image', 'infra_wazuh_indexer_container_image', 'infra_wazuh_dashboard_container_image')
-infra_wazuh_version: 4.11.0
+infra_wazuh_version: "4.14.6"
 # Version of the wazuh Docker image to use (see 'infra_wazuh_certtool_container_image')
-infra_wazuh_certtool_version: 0.0.2
+infra_wazuh_certtool_version: "0.0.4"
 
 ## authentik forward auth proxy
 # whether to use authentik as an auth proxy

--- a/tasks/deploy_authentik.yml
+++ b/tasks/deploy_authentik.yml
@@ -16,6 +16,20 @@
     mode: "{{ infra_authentik_subdirectory_mode }}"
   with_items: "{{ infra_authentik_subdirectories }}"
 
+- name: Move existing 'media' subdirectory to 'data/media'
+  block:
+    - name: Stat old media subdirectory
+      ansible.builtin.stat:
+        path: "{{ infra_authentik_directory_path }}/media"
+      register: infra_authentik_media_subdir_stat_output
+
+    - name: Move 'media' to 'data/media'
+      when: infra_authentik_media_subdir_stat_output.stat.isdir is defined and infra_authentik_media_subdir_stat_output.stat.isdir
+      ansible.builtin.command:
+        cmd: mv "{{ infra_authentik_directory_path }}/media" "{{ infra_authentik_directory_path }}/data/"
+        creates: "{{ infra_authentik_directory_path }}/data/media"
+        removes: "{{ infra_authentik_directory_path }}/media"
+
 - name: Manage service files
   block:
     - name: Write authentik DB password secret to file

--- a/templates/compose/authentik.yml.j2
+++ b/templates/compose/authentik.yml.j2
@@ -38,7 +38,7 @@ services:
       options: {{ svc_log_options }}
     env_file: {{ infra_authentik_env_file_path }}
     volumes:
-      - {{ infra_authentik_directory_path }}/media:/media
+      - {{ infra_authentik_directory_path }}/data:/data
       - {{ infra_authentik_directory_path }}/templates:/templates
     mem_limit: {{ infra_authentik_container_memory }}
     labels:
@@ -64,6 +64,7 @@ services:
       {{ infra_authentik_db_service_name }}:
         condition: service_healthy
     command: server
+    shm_size: 512mb
 
   {{ infra_authentik_worker_service_name }}:
     image: {{ infra_authentik_container_image }}
@@ -75,7 +76,7 @@ services:
       options: {{ svc_log_options }}
     env_file: {{ infra_authentik_env_file_path }}
     volumes:
-      - {{ infra_authentik_directory_path }}/media:/media
+      - {{ infra_authentik_directory_path }}/data:/data
       - {{ infra_authentik_directory_path }}/templates:/templates
       - {{ infra_authentik_directory_path }}/certs:/certs
     mem_limit: {{ infra_authentik_worker_container_memory }}
@@ -90,6 +91,7 @@ services:
       {{ infra_authentik_db_service_name }}:
         condition: service_healthy
     command: worker
+    shm_size: 512mb
 
 volumes:
   {{ infra_authentik_db_volume_name_data }}:


### PR DESCRIPTION
- Updated actual to `26.7.0`
- Updated authentik to `2025.12.5`
- Updated godns to `v3.4.2`
- Updated homarr to `v1.69.2`
- Updated pihole to `2026.06.0`
- Updated unifi to `10.4.57`
- Updated uptime-kuma to `2.4.0`
- Updated wazuh to `4.14.6`